### PR TITLE
Non-HuBERT SSLs

### DIFF
--- a/scripts/label-audio.py
+++ b/scripts/label-audio.py
@@ -2,6 +2,7 @@ import argparse
 from tqdm import tqdm
 
 import torch
+from transformers import AutoFeatureExtractor
 
 from spire.utils import detokenize
 from spire.hubert_labeler import HubertLabeler
@@ -22,6 +23,7 @@ def main(args):
     labeler = HubertLabeler(
         args.ckpt_path, args.km_path, layer=args.layer, dtype=dtype
     )
+    feature_extractor = AutoFeatureExtractor.from_pretrained(args.ckpt_path)
 
     device = "cpu" if args.cpu else "cuda"
     labeler = labeler.to(device=device)
@@ -31,6 +33,7 @@ def main(args):
 
     loader, n_batches, raw_length = build_dataloader(
         path=args.tsv_path,
+        feature_extractor=feature_extractor,
         batch_size=args.batch_size,
         num_workers=args.num_workers,
         dataset_type=args.dataset_type,

--- a/scripts/label-audio.py
+++ b/scripts/label-audio.py
@@ -46,12 +46,14 @@ def main(args):
         hf_location="disk" if args.dataset_type == "hf-disk" else "cache"
     )
 
+    input_field_name = feature_extractor.model_input_names[0]
+
     with open(args.out_path, "w") as f:
         with torch.no_grad():
             labels = []
             indices = []
             for batch in tqdm(loader, total=n_batches):
-                inp = batch.input_values.to(dtype=dtype, device=device)
+                inp = batch[input_field_name].to(dtype=dtype, device=device)
                 mask = batch.attention_mask
                 if device == "cuda":
                     mask = mask.cuda()

--- a/scripts/label-audio.py
+++ b/scripts/label-audio.py
@@ -5,7 +5,7 @@ import torch
 from transformers import AutoFeatureExtractor
 
 from spire.utils import detokenize
-from spire.hubert_labeler import HubertLabeler
+from spire.labeler import Labeler
 from spire.data import build_dataloader
 
 
@@ -20,9 +20,7 @@ def main(args):
     dtypes = {"bf16": torch.bfloat16, "fp32": torch.float32}
     dtype = dtypes[args.dtype]
 
-    labeler = HubertLabeler(
-        args.ckpt_path, args.km_path, layer=args.layer, dtype=dtype
-    )
+    labeler = Labeler(args.ckpt_path, args.km_path, layer=args.layer, dtype=dtype)
     feature_extractor = AutoFeatureExtractor.from_pretrained(args.ckpt_path)
 
     device = "cpu" if args.cpu else "cuda"

--- a/scripts/save-features.py
+++ b/scripts/save-features.py
@@ -48,29 +48,28 @@ def main(args):
         pin_memory=not args.cpu
     )
 
-    # I think I don't need to use AutoFeatureExtractor here. The spire data
-    # code should apply the Wav2Vec2FeatureExtractor, which as far as I know is
-    # appropriate (but we can revisit this if it turns out to be wrong).
+    # past: specified hour-long shards by multiplying hubert fps by 3600
+    # shard_size = 3600 * 50  # an hour of frames
+    # shard_frames = 0
 
-    # (however, I should change this later when I make the code extensible)
+    # present: directly specify number of *hours* per shard
+    shard_hours = 0.
 
-    # processor = AutoFeatureExtractor.from_pretrained(args.ssl_model)
-    # model = Wav2Vec2BertModel.from_pretrained(args.ssl_model).to(device)
-    # model.eval()
+    # future idea: specify size of shard in *either* hours or frames
+    # (but not both)
 
-    shard_size = 3600 * 50  # an hour of frames
-
-    shard_frames = 0
     n_hours = 0.
     shard_index = 0
 
     os.makedirs(args.feature_dir, exist_ok=True)
     feat_f = NpyAppendArray(join(args.feature_dir, f"shard_{shard_index}.npy"))
 
+    input_field_name = feature_extractor.model_input_names[0]
+
     with torch.no_grad():
         with tqdm(total=args.max_hours) as pbar:
             for batch in loader:
-                inp = batch.input_values.to(dtype=dtype, device=device)
+                inp = batch[input_field_name].to(dtype=dtype, device=device)
 
                 mask = batch.attention_mask
                 if device == "cuda":
@@ -85,19 +84,19 @@ def main(args):
                     flatten=True,
                     return_pad_percent=True
                 )
-                # flatten=True removes padding positions
-                batch_frames = features.shape[0]
-                batch_hours = mask.sum().item() / (args.resample_to * 3600)
+
+                batch_hours = sum(batch["seconds"]) / 3600
 
                 feat_f.append(features.cpu().float().numpy())
 
-                shard_frames += batch_frames
+                # shard_frames += batch_frames
 
                 # update hours seen
+                shard_hours += batch_hours
                 n_hours += batch_hours
 
-                if shard_frames >= shard_size or n_hours >= args.max_hours:
-                    shard_frames = 0
+                if shard_hours >= args.hours_per_shard or n_hours >= args.max_hours:
+                    shard_hours = 0.
 
                     shard_index += 1
                     feat_f = NpyAppendArray(join(args.feature_dir, f"shard_{shard_index}.npy"))
@@ -135,5 +134,6 @@ if __name__ == "__main__":
     parser.add_argument("--validate-examples", action="store_true")
     parser.add_argument("--cpu", action="store_true", help="only useful for debugging")
     parser.add_argument("--feature-dir")
+    parser.add_argument("--hours-per-shard", type=float, default=1.)
     args = parser.parse_args()
     main(args)

--- a/scripts/save-features.py
+++ b/scripts/save-features.py
@@ -7,7 +7,7 @@ import torch
 from transformers import AutoFeatureExtractor
 from npy_append_array import NpyAppendArray
 
-from spire.hubert_labeler import Featurizer
+from spire.labeler import Featurizer
 from spire.data import build_dataloader
 
 

--- a/scripts/save-features.py
+++ b/scripts/save-features.py
@@ -4,6 +4,7 @@ from os.path import join
 
 from tqdm import tqdm
 import torch
+from transformers import AutoFeatureExtractor
 from npy_append_array import NpyAppendArray
 
 from spire.hubert_labeler import Featurizer
@@ -20,6 +21,8 @@ def main(args):
     torch_random = torch.Generator(device="cpu")  # DataLoader always uses CPU
     torch_random.manual_seed(args.torch_seed)
 
+    feature_extractor = AutoFeatureExtractor.from_pretrained(args.ssl_model)
+
     featurizer = Featurizer(args.ssl_model, layer=args.layer, dtype=dtype)
 
     featurizer = featurizer.to(device=device)
@@ -29,6 +32,7 @@ def main(args):
 
     loader, n_batches, raw_length = build_dataloader(
         path=args.data_path,
+        feature_extractor=feature_extractor,
         batch_size=args.batch_size,
         num_workers=args.num_workers,
         dataset_type=args.dataset_type,

--- a/spire/__init__.py
+++ b/spire/__init__.py
@@ -1,4 +1,4 @@
 import spire.tokenizer_extension
 import spire.utils
 import spire.data
-import spire.hubert_labeler
+import spire.labeler

--- a/spire/data.py
+++ b/spire/data.py
@@ -43,6 +43,7 @@ def collate_fn(inputs, feature_extractor):
         return_attention_mask=True
     )
     batch["indices"] = [inp["idx"] for inp in inputs]
+    batch["seconds"] = [audio.shape[0] / feature_extractor.sampling_rate for audio in audios]
     return batch
 
 
@@ -56,6 +57,7 @@ def collate_hf(inputs, feature_extractor):
         return_attention_mask=True
     )
     batch["indices"] = [inp["idx"] for inp in inputs]
+    batch["seconds"] = [audio.shape[0] / feature_extractor.sampling_rate for audio in audios]
     return batch
 
 

--- a/spire/data.py
+++ b/spire/data.py
@@ -159,7 +159,7 @@ def get_valid_indices(dataset):
 
 
 def build_dataloader(
-        path, num_workers=0, batch_size=1, dataset_type="tsv", start_ix=0,
+        path, feature_extractor, num_workers=0, batch_size=1, dataset_type="tsv", start_ix=0,
         n_examples=0, validate_examples=False, path_extra="en", hf_location="disk",
         hf_split="test", resample_to=None, shuffle=False, torch_random=None, pin_memory=False):
 
@@ -191,7 +191,7 @@ def build_dataloader(
     print("Raw: {}\tAfter validating: {}".format(length_before_validating, len(dataset)))
 
     # build the collator
-    feature_extractor = Wav2Vec2FeatureExtractor()
+    # feature_extractor = Wav2Vec2FeatureExtractor()
     collate_func = collate_fn if dataset_type == "tsv" else collate_hf
     collator = partial(collate_func, feature_extractor=feature_extractor)
 

--- a/spire/labeler.py
+++ b/spire/labeler.py
@@ -86,9 +86,13 @@ class KMeans(nn.Module):
         return dist
 
 
-class HubertLabeler(nn.Module):
+class Labeler(nn.Module):
 
     def __init__(self, ckpt_path, km_path, layer=22, dtype=torch.float32):
+        """
+        The layer default of 22 is a strong value for HuBERT-large. It may be
+        inappropriate for other models.
+        """
         super().__init__()
 
         self.featurizer = Featurizer(ckpt_path, layer=layer, dtype=dtype)

--- a/spire/utils.py
+++ b/spire/utils.py
@@ -1,6 +1,7 @@
 from os.path import exists, join, basename, dirname
 import unicodedata
 
+import numpy as np
 import soundfile as sf
 from transformers import Wav2Vec2FeatureExtractor
 


### PR DESCRIPTION
This pull request adds support for w2v-bert-2.0. This required a small refactor of the Featurizer and scripts that use it, in order to account for different `FeatureExtractor` configurations.

I also changed how hours are computed in save-features.py. Instead of relying on the number of model output frames seen (which my vary in the future if used with models with different framerates), the batch collation code is changed so that it computes the length of each example when batches are created.