### PR TITLE
Support for more speech encoders

### DIFF
--- a/scripts/features-and-kmeans.py
+++ b/scripts/features-and-kmeans.py
@@ -80,7 +80,8 @@ def main(args):
         n_examples=args.n_examples,
         resample_to=args.resample_to,
         token_batching=args.token_batching,
-        example_lengths=args.example_lengths
+        example_lengths=args.example_lengths,
+        torch_random=torch_random
     )
 
     n_hours = 0.

--- a/scripts/features-and-kmeans.py
+++ b/scripts/features-and-kmeans.py
@@ -59,7 +59,7 @@ def main(args):
     featurizer = Featurizer(
         args.ssl_model,
         layer=args.layer,
-        no_final_layer_norm=args.no_final_layer_norm,
+        keep_final_layer_norm=args.keep_final_layer_norm,
         dtype=dtype,
         pooling_width=args.pooling_width,
         pooling_type=args.pooling_type

--- a/scripts/features-and-kmeans.py
+++ b/scripts/features-and-kmeans.py
@@ -59,6 +59,7 @@ def main(args):
     featurizer = Featurizer(
         args.ssl_model,
         layer=args.layer,
+        no_final_layer_norm=args.no_final_layer_norm,
         dtype=dtype,
         pooling_width=args.pooling_width,
         pooling_type=args.pooling_type

--- a/scripts/label-audio.py
+++ b/scripts/label-audio.py
@@ -26,6 +26,7 @@ def main(args):
         args.ssl_model,
         args.kmeans_model,
         layer=args.layer,
+        no_final_layer_norm=args.no_final_layer_norm,
         dtype=dtype,
         pooling_width=args.pooling_width,
         pooling_type=args.pooling_type

--- a/scripts/label-audio.py
+++ b/scripts/label-audio.py
@@ -26,7 +26,7 @@ def main(args):
         args.ssl_model,
         args.kmeans_model,
         layer=args.layer,
-        no_final_layer_norm=args.no_final_layer_norm,
+        keep_final_layer_norm=args.keep_final_layer_norm,
         dtype=dtype,
         pooling_width=args.pooling_width,
         pooling_type=args.pooling_type

--- a/scripts/save-features.py
+++ b/scripts/save-features.py
@@ -27,7 +27,7 @@ def main(args):
     featurizer = Featurizer(
         args.ssl_model,
         layer=args.layer,
-        no_final_layer_norm=args.no_final_layer_norm,
+        keep_final_layer_norm=args.keep_final_layer_norm,
         dtype=dtype,
         pooling_width=args.pooling_width,
         pooling_type=args.pooling_type

--- a/scripts/save-features.py
+++ b/scripts/save-features.py
@@ -27,6 +27,7 @@ def main(args):
     featurizer = Featurizer(
         args.ssl_model,
         layer=args.layer,
+        no_final_layer_norm=args.no_final_layer_norm,
         dtype=dtype,
         pooling_width=args.pooling_width,
         pooling_type=args.pooling_type

--- a/spire/cli.py
+++ b/spire/cli.py
@@ -12,10 +12,10 @@ CLI arguments for speech encoders, including for managing which device they
 are on
 """
 ssl_parser = argparse.ArgumentParser(add_help=False)
-# currently --ckpt_path in label-audio.py
 ssl_parser.add_argument("--ssl-model", default="facebook/hubert-large-ll60k",
                         help="also try others like facebook/w2v-bert-2.0")
-ssl_parser.add_argument("--layer", type=int, default=22)
+ssl_parser.add_argument("--layer", type=int, default=None)
+ssl_parser.add_argument("--keep-final-layer-norm", action="store_true")
 ssl_parser.add_argument("--dtype", default="fp32", choices=["fp32", "bf16"])
 ssl_parser.add_argument("--compile", action="store_true")  # I guess?
 ssl_parser.add_argument("--pooling-width", type=int, default=1, help="1 recovers no pooling")
@@ -45,6 +45,6 @@ dataset_parser.add_argument("--example-lengths", default=None)
 CLI arguments for DSUs
 """
 dsu_parser = argparse.ArgumentParser(add_help=False)  # as in for the kmeans model stuff
-dsu_parser.add_argument("--kmeans-model", default="/mnt/scratch-artemis/kshitij/clustering/kmeans_model/3datsets_combined_kmeans_5000")
+dsu_parser.add_argument("--kmeans-model", required=True)
 dsu_parser.add_argument("--as-indices", action="store_true")
 dsu_parser.add_argument("--no-dedup", action="store_true")

--- a/spire/data.py
+++ b/spire/data.py
@@ -6,6 +6,7 @@ import soundfile as sf
 import numpy as np
 import torch
 from torch.utils.data import Dataset, Sampler, SequentialSampler, RandomSampler, BatchSampler, DataLoader
+from transformers import WhisperFeatureExtractor
 from datasets import load_from_disk, load_dataset, Audio
 
 
@@ -73,9 +74,10 @@ def collate_fn(inputs, feature_extractor, hf_dataset=True):
         audios,
         sampling_rate=feature_extractor.sampling_rate,
         return_tensors="pt",
-        padding=True,
+        padding="max_length" if isinstance(feature_extractor, WhisperFeatureExtractor) else "longest",
         return_attention_mask=True
     )
+
     batch["indices"] = [inp["idx"] for inp in inputs]
     if "seconds" not in inputs[0]:
         batch["seconds"] = [audio.shape[0] / feature_extractor.sampling_rate for audio in audios]

--- a/spire/labeler.py
+++ b/spire/labeler.py
@@ -178,7 +178,7 @@ class KMeans(nn.Module):
 
 class Labeler(nn.Module):
 
-    def __init__(self, ckpt_path, km_path, layer=None, dtype=torch.float32, pooling_width=1, pooling_type="mean"):
+    def __init__(self, ckpt_path, km_path, layer=None, dtype=torch.float32, pooling_width=1, pooling_type="mean", keep_final_layer_norm=False):
         """
         22 is a strong default value for HuBERT-large. It may be
         inappropriate for other models.
@@ -190,7 +190,8 @@ class Labeler(nn.Module):
             layer=layer,
             dtype=dtype,
             pooling_width=pooling_width,
-            pooling_type=pooling_type
+            pooling_type=pooling_type,
+            keep_final_layer_norm=keep_final_layer_norm
         )
         self.kmeans = KMeans(km_path, dtype=dtype)
 

--- a/spire/labeler.py
+++ b/spire/labeler.py
@@ -59,10 +59,10 @@ def _lengths_to_mask(lengths, max_length, dtype, device):
 
 class Featurizer(nn.Module):
 
-    def __init__(self, ckpt_path, layer=22, dtype=torch.float32, pooling_width=1, pooling_type="mean"):
+    def __init__(self, ckpt_path, layer=None, dtype=torch.float32, pooling_width=1, pooling_type="mean", keep_final_layer_norm=False):
         super().__init__()
 
-        self.model = self._init_model(ckpt_path, layer, dtype)
+        self.model = self._init_model(ckpt_path, layer, dtype, keep_final_layer_norm)
 
         if pooling_width > 1:
             # do I want ceil_mode?
@@ -73,13 +73,13 @@ class Featurizer(nn.Module):
         else:
             self.pooling = None
 
-    def _init_model(self, ckpt_path, layer, dtype):
+    def _init_model(self, ckpt_path, layer, dtype, keep_final_layer_norm):
         model_type = AutoConfig.from_pretrained(ckpt_path).model_type
         adapter = MODEL_ADAPTERS.get(model_type, None)
         if adapter is None:
             raise ValueError(f"Unknown model type {model_type}")
         model = AutoModel.from_pretrained(ckpt_path, torch_dtype=dtype)
-        model = adapter(model, layer=layer, remove_final_layer_norm=True)
+        model = adapter(model, layer=layer, remove_final_layer_norm=not keep_final_layer_norm)
         return model
 
     def _get_feature_vector_attention_mask(self, length, attention_mask):
@@ -178,9 +178,9 @@ class KMeans(nn.Module):
 
 class Labeler(nn.Module):
 
-    def __init__(self, ckpt_path, km_path, layer=22, dtype=torch.float32, pooling_width=1, pooling_type="mean"):
+    def __init__(self, ckpt_path, km_path, layer=None, dtype=torch.float32, pooling_width=1, pooling_type="mean"):
         """
-        The layer default of 22 is a strong value for HuBERT-large. It may be
+        22 is a strong default value for HuBERT-large. It may be
         inappropriate for other models.
         """
         super().__init__()

--- a/spire/labeler.py
+++ b/spire/labeler.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 import joblib
-from transformers import AutoModel, AutoConfig, HubertModel, Wav2Vec2BertModel, WhisperModel
+from transformers import AutoModel, AutoConfig
 from transformers.models.whisper.modeling_whisper import WhisperEncoder
 
 
@@ -83,11 +83,17 @@ class Featurizer(nn.Module):
         return model
 
     def _get_feature_vector_attention_mask(self, length, attention_mask):
-        return self.model._get_feature_vector_attention_mask(length, attention_mask)
-
-    def _get_feature_vector_attention_mask(self, length, attention_mask):
+        """
+        Compute the attention mask for the output of the featurizer. For models like HuBERT, this
+        means calling their internal _get_feature_vector_attention_mask. For Whisper, no such function
+        exists, so it needs to be downsampled here. The input attention_mask will be of shape batch x 3000.
+        The output will be downsampled to batch x 1500.
+        """
         if isinstance(self.model, WhisperEncoder):
-            return attention_mask[:, :length].bool()
+            # downsample by a factor of 2, taking the max of each pair of adjacent positions
+            attention_mask = attention_mask.unsqueeze(1)  # batch x 1 x seq_len
+            attention_mask = torch.nn.functional.max_pool1d(attention_mask.float(), kernel_size=2, stride=2)
+            return attention_mask.squeeze(1).bool()  # batch x seq_len // 2
         else:
             return self.model._get_feature_vector_attention_mask(length, attention_mask)
 
@@ -97,11 +103,10 @@ class Featurizer(nn.Module):
         If flatten == False, return batch x seq_len x D
         If flatten == True, return N x D, where N <= batch*seq_len == the number of non-pad positions
         """
-        # is there a good reason not to have this assertion?
         assert attention_mask is not None
 
         feats = self.model(batch, attention_mask=attention_mask).last_hidden_state
-        pre_pool_max_len = feats.shape[1]
+        pre_pool_max_len = feats.shape[1]  # always 1500 for whisper models
 
         if self.pooling is not None:
             feats = self.pooling(feats.transpose(1, 2)).transpose(1, 2)

--- a/spire/labeler.py
+++ b/spire/labeler.py
@@ -1,7 +1,42 @@
 import torch
 import torch.nn as nn
 import joblib
-from transformers import AutoModel, HubertModel, Wav2Vec2BertModel
+from transformers import AutoModel, AutoConfig, HubertModel, Wav2Vec2BertModel, WhisperModel
+from transformers.models.whisper.modeling_whisper import WhisperEncoder
+
+
+def adapt_hubert(model, layer=None, remove_final_layer_norm=True):
+    if remove_final_layer_norm:
+        model.encoder.layer_norm = nn.Identity()  # kludge to avoid applying final layer norm
+    if layer is not None:
+        model.encoder.layers = model.encoder.layers[:layer]
+    return model
+
+
+def adapt_w2v_bert(model, layer=None, remove_final_layer_norm=True):
+    if layer is not None:
+        model.encoder.layers = model.encoder.layers[:layer]
+    if remove_final_layer_norm:
+        model.encoder.layers[-1].final_layer_norm = nn.Identity()
+    return model
+
+
+def adapt_whisper(model, layer=None, remove_final_layer_norm=True):
+    model = model.encoder
+    if layer is not None:
+        model.layers = model.layers[:layer]
+    if remove_final_layer_norm:
+        model.layers[-1].final_layer_norm = nn.Identity()
+    return model
+
+
+# keys are with AutoConfig.from_pretrained(path).model_type
+MODEL_ADAPTERS = {
+    "hubert": adapt_hubert,
+    "wav2vec2-bert": adapt_w2v_bert,
+    "whisper": adapt_whisper,
+    "wav2vec2": adapt_hubert,
+}
 
 
 def _pool_out_length(input_length, pooling_size, stride=None):
@@ -27,18 +62,7 @@ class Featurizer(nn.Module):
     def __init__(self, ckpt_path, layer=22, dtype=torch.float32, pooling_width=1, pooling_type="mean"):
         super().__init__()
 
-        self.model = AutoModel.from_pretrained(ckpt_path, torch_dtype=dtype)
-
-        if isinstance(self.model, HubertModel):
-            self.model.encoder.layer_norm = nn.Identity()  # kludge to avoid applying final layer norm
-            self.model.encoder.layers = self.model.encoder.layers[:layer]
-        elif isinstance(self.model, Wav2Vec2BertModel):
-            # I *think* this is the way to go for getting SSL features from a
-            # w2v model
-            self.model.encoder.layers = self.model.encoder.layers[:layer]
-            self.model.encoder.layers[-1].final_layer_norm = nn.Identity()
-        else:
-            raise ValueError("Unknown SSL architecture")
+        self.model = self._init_model(ckpt_path, layer, dtype)
 
         if pooling_width > 1:
             # do I want ceil_mode?
@@ -49,8 +73,23 @@ class Featurizer(nn.Module):
         else:
             self.pooling = None
 
+    def _init_model(self, ckpt_path, layer, dtype):
+        model_type = AutoConfig.from_pretrained(ckpt_path).model_type
+        adapter = MODEL_ADAPTERS.get(model_type, None)
+        if adapter is None:
+            raise ValueError(f"Unknown model type {model_type}")
+        model = AutoModel.from_pretrained(ckpt_path, torch_dtype=dtype)
+        model = adapter(model, layer=layer, remove_final_layer_norm=True)
+        return model
+
     def _get_feature_vector_attention_mask(self, length, attention_mask):
         return self.model._get_feature_vector_attention_mask(length, attention_mask)
+
+    def _get_feature_vector_attention_mask(self, length, attention_mask):
+        if isinstance(self.model, WhisperEncoder):
+            return attention_mask[:, :length].bool()
+        else:
+            return self.model._get_feature_vector_attention_mask(length, attention_mask)
 
     def forward(self, batch, attention_mask=None, flatten=False, return_pad_percent=False):
         """


### PR DESCRIPTION
This pull request adds support for more speech encoders besides Hubert and w2v-bert. Although other model families haven't been tested rigorously, tokenization results with whisper-large-v3 seem sensible. It should be easy to add new model types by extending `MODEL_ADAPTERS` in `spire/data.py`.